### PR TITLE
Allow dockerfile to be specified for default composition

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
   "types": "build/index.d.ts",
   "scripts": {
     "clean": "rimraf '{src,test,typings}/**/*.{js,js.map}'",
-    "lint": "tslint '{src,test,typings}/**/*.ts'",
+    "lint": "resin-lint --typescript src/ test/ && tsc --noEmit",
     "copySchemas": "mkdir -p build/schemas && cp src/schemas/*.json build/schemas/",
     "build": "npm run clean && tsc --project ./ && npm run copySchemas",
     "test": "npm run lint && ts-mocha --project ./ test/**/*.spec.ts",
     "prepublish": "require-npm4-to-publish",
-    "prepublishOnly": "npm run build && npm test"
+    "prepublishOnly": "npm run build && npm test",
+    "prettify": "prettier --config ./node_modules/resin-lint/config/.prettierrc --write \"{src,test,typings}/**/*.ts\""
   },
   "repository": {
     "type": "git",
@@ -36,10 +37,11 @@
     "chai": "^4.1.2",
     "js-yaml": "^3.10.0",
     "mocha": "^3.2.0",
+    "prettier": "^1.16.4",
     "require-npm4-to-publish": "^1.0.0",
+    "resin-lint": "^3.0.1",
     "rimraf": "^2.6.2",
     "ts-mocha": "^1.0.3",
-    "tslint": "^5.8.0",
-    "typescript": "^2.6.2"
+    "typescript": "^3.2.1"
   }
 }

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -2,8 +2,22 @@ import * as _ from 'lodash';
 import * as path from 'path';
 
 import { InternalInconsistencyError, ValidationError } from './errors';
-import { DEFAULT_SCHEMA_VERSION, SchemaError, SchemaVersion, validate } from './schemas';
-import { BuildConfig, Composition, Dict, ImageDescriptor, ListOrDict, Network, Service, Volume } from './types';
+import {
+	DEFAULT_SCHEMA_VERSION,
+	SchemaError,
+	SchemaVersion,
+	validate,
+} from './schemas';
+import {
+	BuildConfig,
+	Composition,
+	Dict,
+	ImageDescriptor,
+	ListOrDict,
+	Network,
+	Service,
+	Volume,
+} from './types';
 
 // tslint:disable-next-line
 const packageJson = require('../package.json');
@@ -66,13 +80,13 @@ export function normalize(o: any): Composition {
 		switch (c.version) {
 			case '2':
 			case '2.0':
-			version = SchemaVersion.v2_0;
-			break;
-		case '2.1':
-			version = SchemaVersion.v2_1;
-			break;
-		default:
-			throw new ValidationError('Unsupported composition version');
+				version = SchemaVersion.v2_0;
+				break;
+			case '2.1':
+				version = SchemaVersion.v2_1;
+				break;
+			default:
+				throw new ValidationError('Unsupported composition version');
 		}
 	}
 
@@ -89,39 +103,39 @@ export function normalize(o: any): Composition {
 
 	while (true) {
 		switch (version) {
-		case SchemaVersion.v1_0:
-			version = SchemaVersion.v2_0;
-			c = { version, services: c };
-			// FIXME: perform attribute migration
-			break;
-		case SchemaVersion.v2_0:
-			version = SchemaVersion.v2_1;
-			c.version = version;
-			/* no attributes migration needed for 2.0->2.1 */
-			break;
-		case SchemaVersion.v2_1:
-			// Normalise volumes
-			if (c.volumes) {
-				const volumes: Dict<Volume> = c.volumes;
-				c.volumes = _.mapValues(volumes, normalizeVolume);
-			}
+			case SchemaVersion.v1_0:
+				version = SchemaVersion.v2_0;
+				c = { version, services: c };
+				// FIXME: perform attribute migration
+				break;
+			case SchemaVersion.v2_0:
+				version = SchemaVersion.v2_1;
+				c.version = version;
+				/* no attributes migration needed for 2.0->2.1 */
+				break;
+			case SchemaVersion.v2_1:
+				// Normalise volumes
+				if (c.volumes) {
+					const volumes: Dict<Volume> = c.volumes;
+					c.volumes = _.mapValues(volumes, normalizeVolume);
+				}
 
-			// Normalise services
-			const services: Dict<Service> = c.services || { };
-			const serviceNames = _.keys(services);
-			const volumeNames = _.keys(c.volumes);
+				// Normalise services
+				const services: Dict<Service> = c.services || {};
+				const serviceNames = _.keys(services);
+				const volumeNames = _.keys(c.volumes);
 
-			c.services = _.mapValues(services, (service) => {
-				return normalizeService(service, serviceNames, volumeNames);
-			});
+				c.services = _.mapValues(services, service => {
+					return normalizeService(service, serviceNames, volumeNames);
+				});
 
-			// Normalise networks
-			if (c.networks) {
-				const networks: Dict<Network> = c.networks;
-				c.networks = _.mapValues(networks, normalizeNetwork);
-			}
+				// Normalise networks
+				if (c.networks) {
+					const networks: Dict<Network> = c.networks;
+					c.networks = _.mapValues(networks, normalizeNetwork);
+				}
 
-			return c as Composition;
+				return c as Composition;
 		}
 	}
 }
@@ -138,7 +152,11 @@ function preflight(_version: SchemaVersion, data: any) {
 	}
 }
 
-function normalizeService(service: Service, serviceNames: string[], volumeNames: string[]): Service {
+function normalizeService(
+	service: Service,
+	serviceNames: string[],
+	volumeNames: string[],
+): Service {
 	if (!service.image && !service.build) {
 		throw new ValidationError('You must specify either an image or a build');
 	}
@@ -163,7 +181,7 @@ function normalizeService(service: Service, serviceNames: string[], volumeNames:
 		if (_.uniq(service.depends_on).length !== service.depends_on.length) {
 			throw new ValidationError('Service dependencies must be unique');
 		}
-		service.depends_on.forEach((dep) => {
+		service.depends_on.forEach(dep => {
 			if (!_.includes(serviceNames, dep)) {
 				throw new ValidationError(`Unknown service dependency: ${dep}`);
 			}
@@ -178,7 +196,9 @@ function normalizeService(service: Service, serviceNames: string[], volumeNames:
 		if (!_.isArray(service.extra_hosts)) {
 			// At this point we know that the extra_hosts entry is an object, so cast to
 			// keep TS happy
-			service.extra_hosts = normalizeExtraHostObject(service.extra_hosts as any);
+			service.extra_hosts = normalizeExtraHostObject(
+				service.extra_hosts as any,
+			);
 		}
 	}
 
@@ -192,7 +212,7 @@ function normalizeService(service: Service, serviceNames: string[], volumeNames:
 	}
 
 	if (service.volumes) {
-		service.volumes.forEach((volume) => {
+		service.volumes.forEach(volume => {
 			validateServiceVolume(volume, volumeNames);
 		});
 	}
@@ -223,8 +243,9 @@ function validateLabels(labels: Dict<string>) {
 		if (!/^[a-zA-Z0-9.-]+$/.test(name)) {
 			throw new ValidationError(
 				`Invalid label name: "${name}". ` +
-				'Label names must only contain alphanumeric ' +
-				'characters, periods "." and dashes "-".');
+					'Label names must only contain alphanumeric ' +
+					'characters, periods "." and dashes "-".',
+			);
 		}
 	});
 }
@@ -259,12 +280,15 @@ export function parse(c: Composition): ImageDescriptor[] {
 	if (c.version !== DEFAULT_SCHEMA_VERSION) {
 		throw new Error('Unsupported composition version');
 	}
-	return _.toPairs(c.services).map(([ name, service ]) => {
+	return _.toPairs(c.services).map(([name, service]) => {
 		return createImageDescriptor(name, service);
 	});
 }
 
-function createImageDescriptor(serviceName: string, service: Service): ImageDescriptor {
+function createImageDescriptor(
+	serviceName: string,
+	service: Service,
+): ImageDescriptor {
 	if (service.image && !service.build) {
 		return { serviceName, image: service.image };
 	}
@@ -294,15 +318,18 @@ function createImageDescriptor(serviceName: string, service: Service): ImageDesc
 	return { serviceName, image: build };
 }
 
-function normalizeKeyValuePairs(obj?: ListOrDict, sep: string = '='): Dict<string> {
+function normalizeKeyValuePairs(
+	obj?: ListOrDict,
+	sep: string = '=',
+): Dict<string> {
 	if (!obj) {
 		return {};
 	}
 	if (!_.isArray(obj)) {
 		return _(obj)
 			.toPairs()
-			.map(([ key, value ]) => {
-				return [ key, value ? ('' + value).trim() : '' ];
+			.map(([key, value]) => {
+				return [key, value ? ('' + value).trim() : ''];
 			})
 			.fromPairs()
 			.value();
@@ -310,10 +337,10 @@ function normalizeKeyValuePairs(obj?: ListOrDict, sep: string = '='): Dict<strin
 	return _(obj)
 		.map(val => {
 			const parts = val.split(sep);
-			return [ parts.shift()!, parts.join('=') ];
+			return [parts.shift()!, parts.join('=')];
 		})
-		.map(([ key, value ]) => {
-			return [ key.trim(), value ? value.trim() : '' ];
+		.map(([key, value]) => {
+			return [key.trim(), value ? value.trim() : ''];
 		})
 		.fromPairs()
 		.value();

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -23,12 +23,19 @@ import {
 const packageJson = require('../package.json');
 const packageVersion = packageJson.version;
 
-export function defaultComposition(image?: string): string {
+export function defaultComposition(
+	image?: string,
+	dockerfile?: string,
+): string {
 	let context: string;
 	if (image) {
 		context = `image: ${image}`;
 	} else {
-		context = 'build: "."';
+		if (dockerfile) {
+			context = `build: {context: ".", dockerfile: "${dockerfile}"}`;
+		} else {
+			context = 'build: "."';
+		}
 	}
 	return `# Auto-generated compose file by resin-compose-parse@v${packageVersion}
 version: '2.1'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,19 @@
 import { defaultComposition, normalize, parse } from './compose';
 import { ValidationError } from './errors';
-import { DEFAULT_SCHEMA_VERSION, SchemaError, SchemaVersion, validate } from './schemas';
-import { BuildConfig, Composition, ImageDescriptor, Network, Service, Volume } from './types';
+import {
+	DEFAULT_SCHEMA_VERSION,
+	SchemaError,
+	SchemaVersion,
+	validate,
+} from './schemas';
+import {
+	BuildConfig,
+	Composition,
+	ImageDescriptor,
+	Network,
+	Service,
+	Volume,
+} from './types';
 
 export {
 	defaultComposition,

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -52,7 +52,9 @@ export function validate(version: SchemaVersion, data: any): void {
 }
 
 function validatePorts(value: string): boolean {
-	return /^(?:(?:([a-fA-F\d.:]+):)?([\d]*)(?:-([\d]+))?:)?([\d]+)(?:-([\d]+))?(?:\/(udp|tcp))?$/.test(value);
+	return /^(?:(?:([a-fA-F\d.:]+):)?([\d]*)(?:-([\d]+))?:)?([\d]+)(?:-([\d]+))?(?:\/(udp|tcp))?$/.test(
+		value,
+	);
 }
 
 function validateExpose(value: string | number): boolean {
@@ -66,13 +68,14 @@ function validateDuration(value: string | number): boolean {
 
 	const re = new RegExp(
 		'^' +
-		'(?:([\\d.]+)h)?' +
-		'(?:([\\d.]+)m)?' +
-		'(?:([\\d.]+)s)?' +
-		'(?:([\\d.]+)ms)?' +
-		'(?:([\\d.]+)us)?' +
-		'(?:([\\d.]+)ns)?' +
-		'$');
+			'(?:([\\d.]+)h)?' +
+			'(?:([\\d.]+)m)?' +
+			'(?:([\\d.]+)s)?' +
+			'(?:([\\d.]+)ms)?' +
+			'(?:([\\d.]+)us)?' +
+			'(?:([\\d.]+)ns)?' +
+			'$',
+	);
 
 	return re.test(value);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-
 // Types for Docker Compose File schema v2.1
 // https://docs.docker.com/compose/compose-file/compose-file-v2/
 
@@ -93,7 +92,16 @@ export interface Service {
 	links?: ListOfUniqueItems<string>;
 
 	logging?: {
-		driver?: 'json-file' | 'syslog' | 'journald' | 'gelf' | 'fluentd' | 'awslogs' | 'splunk' | 'etwlogs' | 'none';
+		driver?:
+			| 'json-file'
+			| 'syslog'
+			| 'journald'
+			| 'gelf'
+			| 'fluentd'
+			| 'awslogs'
+			| 'splunk'
+			| 'etwlogs'
+			| 'none';
 		options?: Dict<any>;
 	};
 
@@ -105,12 +113,14 @@ export interface Service {
 	memswap_limit?: number | ByteValue;
 
 	network_mode?: string;
-	networks?: ListOfUniqueItems<string> | Dict<null | {
-		aliases?: ListOfUniqueItems<string>;
-		ipv4_address?: string;
-		ipv6_address?: string;
-		link_local_ips?: ListOfUniqueItems<string>;
-	}>;
+	networks?:
+		| ListOfUniqueItems<string>
+		| Dict<null | {
+				aliases?: ListOfUniqueItems<string>;
+				ipv4_address?: string;
+				ipv6_address?: string;
+				link_local_ips?: ListOfUniqueItems<string>;
+		  }>; // tslint:disable-line indent
 
 	oom_kill_disable?: boolean;
 	oom_score_adj?: number;
@@ -136,10 +146,13 @@ export interface Service {
 	tmpfs?: StringOrList;
 	tty?: boolean;
 
-	ulimits?: Dict<number | {
-		soft: number;
-		hard: number;
-	}>;
+	ulimits?: Dict<
+		| number
+		| {
+				soft: number;
+				hard: number;
+		  } // tslint:disable-line indent
+	>;
 
 	user?: string;
 	userns_mode?: string;

--- a/test/all.spec.ts
+++ b/test/all.spec.ts
@@ -41,6 +41,22 @@ describe('default composition', () => {
 		done();
 	});
 
+	it('with build dockerfile name', done => {
+		const composeStr = compose.defaultComposition(undefined, 'MyDockerfile');
+		const composeJson = yml.safeLoad(composeStr, {
+			schema: yml.FAILSAFE_SCHEMA,
+		});
+		const c = compose.normalize(composeJson);
+		expect(c.version).to.equal('2.1');
+		expect(compose.parse(c)).to.deep.equal([
+			{
+				serviceName: 'main',
+				image: { context: '.', dockerfile: 'MyDockerfile' },
+			},
+		]);
+		done();
+	});
+
 	it('with image', done => {
 		const composeStr = compose.defaultComposition('some/image');
 		const composeJson = yml.safeLoad(composeStr, {

--- a/test/all.spec.ts
+++ b/test/all.spec.ts
@@ -4,20 +4,20 @@ import * as utils from './utils';
 
 import * as compose from '../src';
 
-[ '1.0', '2.0', '2.1' ].forEach((version) => {
+['1.0', '2.0', '2.1'].forEach(version => {
 	const services = [
 		{ serviceName: 's1', image: { context: './' } },
 		{ serviceName: 's2', image: 'some/image' },
 	];
 
 	describe(`v${version}`, () => {
-		it('should migrate composition to default version', (done) => {
+		it('should migrate composition to default version', done => {
 			const composition = utils.loadFixture(`test-v${version}.json`);
 			expect(compose.normalize(composition).version).to.equal('2.1');
 			done();
 		});
 
-		it('should parse composition services', (done) => {
+		it('should parse composition services', done => {
 			const composition = utils.loadFixture(`test-v${version}.json`);
 			const c = compose.normalize(composition);
 			const d = compose.parse(c);
@@ -28,9 +28,11 @@ import * as compose from '../src';
 });
 
 describe('default composition', () => {
-	it('with build context', (done) => {
+	it('with build context', done => {
 		const composeStr = compose.defaultComposition();
-		const composeJson = yml.safeLoad(composeStr, { schema: yml.FAILSAFE_SCHEMA });
+		const composeJson = yml.safeLoad(composeStr, {
+			schema: yml.FAILSAFE_SCHEMA,
+		});
 		const c = compose.normalize(composeJson);
 		expect(c.version).to.equal('2.1');
 		expect(compose.parse(c)).to.deep.equal([
@@ -39,9 +41,11 @@ describe('default composition', () => {
 		done();
 	});
 
-	it('with image', (done) => {
+	it('with image', done => {
 		const composeStr = compose.defaultComposition('some/image');
-		const composeJson = yml.safeLoad(composeStr, { schema: yml.FAILSAFE_SCHEMA });
+		const composeJson = yml.safeLoad(composeStr, {
+			schema: yml.FAILSAFE_SCHEMA,
+		});
 		const c = compose.normalize(composeJson);
 		expect(c.version).to.equal('2.1');
 		expect(compose.parse(c)).to.deep.equal([
@@ -55,12 +59,12 @@ describe('normalization', () => {
 	const composition = utils.loadFixture('default.json');
 	const c = compose.normalize(composition);
 
-	it('should migrate composition to default version', (done) => {
+	it('should migrate composition to default version', done => {
 		expect(c.version).to.equal('2.1');
 		done();
 	});
 
-	it('should parse composition services', (done) => {
+	it('should parse composition services', done => {
 		expect(compose.parse(c)).to.deep.equal([
 			{ serviceName: 's1', image: { context: './s1' } },
 			{ serviceName: 's2', image: { context: './s2' } },
@@ -69,18 +73,13 @@ describe('normalization', () => {
 		done();
 	});
 
-	it('depends_on', (done) => {
-		expect(c.services.s1.depends_on).to.deep.equal([
-			's3',
-		]);
-		expect(c.services.s2.depends_on).to.deep.equal([
-			's1',
-			's3',
-		]);
+	it('depends_on', done => {
+		expect(c.services.s1.depends_on).to.deep.equal(['s3']);
+		expect(c.services.s2.depends_on).to.deep.equal(['s1', 's3']);
 		done();
 	});
 
-	it('environment', (done) => {
+	it('environment', done => {
 		expect(c.services.s1.environment).to.deep.equal({
 			SOME_VAR: 'some=value',
 		});
@@ -90,22 +89,22 @@ describe('normalization', () => {
 		done();
 	});
 
-	it('parses ports converting numbers to strings', (done) => {
-		expect(c.services.s3.ports).to.deep.equal([ '1000', '1001:1002', '1003:1004/tcp' ]);
-		done();
-	});
-
-	it('normalizes extra_hosts from objects or arrays', (done) => {
-		expect(c.services.s2.extra_hosts).to.deep.equal([
-			'foo:127.0.0.1',
-		]);
-		expect(c.services.s3.extra_hosts).to.deep.equal([
-			'bar:8.8.8.8',
+	it('parses ports converting numbers to strings', done => {
+		expect(c.services.s3.ports).to.deep.equal([
+			'1000',
+			'1001:1002',
+			'1003:1004/tcp',
 		]);
 		done();
 	});
 
-	it('networks', (done) => {
+	it('normalizes extra_hosts from objects or arrays', done => {
+		expect(c.services.s2.extra_hosts).to.deep.equal(['foo:127.0.0.1']);
+		expect(c.services.s3.extra_hosts).to.deep.equal(['bar:8.8.8.8']);
+		done();
+	});
+
+	it('networks', done => {
 		expect(c.networks).to.deep.equal({
 			n1: {},
 			n2: {},
@@ -113,7 +112,7 @@ describe('normalization', () => {
 		done();
 	});
 
-	it('volumes', (done) => {
+	it('volumes', done => {
 		expect(c.volumes).to.deep.equal({
 			v1: {},
 			v2: {},
@@ -123,7 +122,7 @@ describe('normalization', () => {
 });
 
 describe('validation', () => {
-	it('should raise if label name contains forbidden characters', (done) => {
+	it('should raise if label name contains forbidden characters', done => {
 		const f = () => {
 			compose.normalize({
 				version: '2.1',
@@ -148,9 +147,7 @@ describe('validation', () => {
 				services: {
 					main: {
 						image: 'some/image',
-						volumes: [
-							'./localPath:/some-place',
-						],
+						volumes: ['./localPath:/some-place'],
 					},
 				},
 			});
@@ -165,9 +162,7 @@ describe('validation', () => {
 				services: {
 					main: {
 						image: 'some/image',
-						volumes: [
-							'/localPath:/some-place',
-						],
+						volumes: ['/localPath:/some-place'],
 					},
 				},
 			});
@@ -182,9 +177,7 @@ describe('validation', () => {
 				services: {
 					main: {
 						image: 'some/image',
-						volumes: [
-							'thisIsNotAValidVolume',
-						],
+						volumes: ['thisIsNotAValidVolume'],
 					},
 				},
 			});
@@ -199,9 +192,7 @@ describe('validation', () => {
 				services: {
 					main: {
 						image: 'some/image',
-						volumes: [
-							'someVolume:/some-place',
-						],
+						volumes: ['someVolume:/some-place'],
 					},
 				},
 				volumes: {
@@ -219,9 +210,7 @@ describe('validation', () => {
 				services: {
 					main: {
 						image: 'some/image',
-						ports: [
-							'1002:1003/tcp',
-						],
+						ports: ['1002:1003/tcp'],
 					},
 				},
 			});
@@ -236,14 +225,14 @@ describe('validation', () => {
 				services: {
 					main: {
 						image: 'some/image',
-						ports: [
-							'1002:1003/tc',
-						],
+						ports: ['1002:1003/tc'],
 					},
 				},
 			});
 		};
-		expect(f).to.throw('data/services/main/ports/0 should match format "ports"');
+		expect(f).to.throw(
+			'data/services/main/ports/0 should match format "ports"',
+		);
 	});
 
 	it('should not fail if a volume definition is present', () => {
@@ -252,9 +241,7 @@ describe('validation', () => {
 			services: {
 				main: {
 					image: 'some/image',
-					volumes: [
-						'someVolume:/some-place',
-					],
+					volumes: ['someVolume:/some-place'],
 				},
 			},
 			volumes: {


### PR DESCRIPTION
Note there are two commits that you may want to review separately: the first larger one is just "Integrate resin-lint and prettier", and the second small one actually implements the feature.

Change-type: minor
Signed-off-by: Paulo Castro <paulo@balena.io>
Connects-To: https://github.com/balena-io/balena-cli/issues/587
