### PR TITLE
Support compose version 2.4

### DIFF
--- a/src/schemas/config_schema_v2.4.json
+++ b/src/schemas/config_schema_v2.4.json
@@ -1,0 +1,506 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "config_schema_v2.1.json",
+  "type": "object",
+
+  "properties": {
+    "version": {
+      "type": "string"
+    },
+
+    "services": {
+      "id": "#/properties/services",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/service"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "networks": {
+      "id": "#/properties/networks",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/network"
+        }
+      }
+    },
+
+    "volumes": {
+      "id": "#/properties/volumes",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/volume"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+
+  "patternProperties": {"^x-": {}},
+  "additionalProperties": false,
+
+  "definitions": {
+
+    "service": {
+      "id": "#/definitions/service",
+      "type": "object",
+
+      "properties": {
+        "blkio_config": {
+          "type": "object",
+          "properties": {
+            "device_read_bps": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_limit"}
+            },
+            "device_read_iops": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_limit"}
+            },
+            "device_write_bps": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_limit"}
+            },
+            "device_write_iops": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_limit"}
+            },
+            "weight": {"type": "integer"},
+            "weight_device": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_weight"}
+            }
+          },
+          "additionalProperties": false
+        },
+
+        "build": {
+          "oneOf": [
+            {"type": "string"},
+            {
+              "type": "object",
+              "properties": {
+                "args": {"$ref": "#/definitions/list_or_dict"},
+                "cache_from": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+                "context": {"type": "string"},
+                "dockerfile": {"type": "string"},
+                "extra_hosts": {"$ref": "#/definitions/list_or_dict"},
+                "host": {"type": "string"},
+                "isolation": {"type": "string"},
+                "labels": {"$ref": "#/definitions/list_or_dict"},
+                "network": {"type": "string"},
+                "shm_size": {"type": ["number", "string"]},
+                "target": {"type": "string"}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "cgroup_parent": {"type": "string"},
+        "command": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ]
+        },
+        "container_name": {"type": "string"},
+        "cpu_shares": {"type": ["number", "string"]},
+        "cpu_quota": {"type": ["number", "string"]},
+        "cpu_rt_runtime": {"type": ["number", "string"]},
+        "cpu_rt_period": {"type": ["number", "string"]},
+        "cpuset": {"type": "string"},
+        "depends_on": {
+          "oneOf": [
+            {"$ref": "#/definitions/list_of_strings"},
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-zA-Z0-9._-]+$": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "condition": {
+                      "type": "string",
+                      "enum": ["service_started", "service_healthy"]
+                    }
+                  },
+                  "required": ["condition"]
+                }
+              }
+            }
+          ]
+        },
+        "devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "device_cgroup_rules": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "dns_opt": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "dns": {"$ref": "#/definitions/string_or_list"},
+        "dns_search": {"$ref": "#/definitions/string_or_list"},
+        "domainname": {"type": "string"},
+        "entrypoint": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ]
+        },
+        "env_file": {"$ref": "#/definitions/string_or_list"},
+        "environment": {"$ref": "#/definitions/list_or_dict"},
+
+        "expose": {
+          "type": "array",
+          "items": {
+            "type": ["string", "number"],
+            "format": "expose"
+          },
+          "uniqueItems": true
+        },
+
+        "extends": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+
+              "properties": {
+                "service": {"type": "string"},
+                "file": {"type": "string"}
+              },
+              "required": ["service"],
+              "additionalProperties": false
+            }
+          ]
+        },
+
+        "external_links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "extra_hosts": {"$ref": "#/definitions/list_or_dict"},
+        "healthcheck": {"$ref": "#/definitions/healthcheck"},
+        "hostname": {"type": "string"},
+        "image": {"type": "string"},
+        "init": {"type": "boolean"},
+        "ipc": {"type": "string"},
+        "isolation": {"type": "string"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+
+        "logging": {
+            "type": "object",
+
+            "properties": {
+                "driver": {"type": "string"},
+                "options": {"type": "object"}
+            },
+            "additionalProperties": false
+        },
+
+        "mac_address": {"type": "string"},
+        "mem_limit": {"type": ["number", "string"]},
+        "mem_reservation": {"type": ["string", "integer"]},
+        "mem_swappiness": {"type": "integer"},
+        "memswap_limit": {"type": ["number", "string"]},
+        "network_mode": {"type": "string"},
+
+        "networks": {
+          "oneOf": [
+            {"$ref": "#/definitions/list_of_strings"},
+            {
+              "type": "object",
+              "patternProperties": {
+                "^[a-zA-Z0-9._-]+$": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "aliases": {"$ref": "#/definitions/list_of_strings"},
+                        "ipv4_address": {"type": "string"},
+                        "ipv6_address": {"type": "string"},
+                        "link_local_ips": {"$ref": "#/definitions/list_of_strings"}
+                      },
+                      "additionalProperties": false
+                    },
+                    {"type": "null"}
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "oom_kill_disable": {"type": "boolean"},
+        "oom_score_adj": {"type": "integer", "minimum": -1000, "maximum": 1000},
+        "group_add": {
+            "type": "array",
+            "items": {
+                "type": ["string", "number"]
+            },
+            "uniqueItems": true
+        },
+        "pid": {"type": ["string", "null"]},
+
+        "ports": {
+          "type": "array",
+          "items": {
+            "type": ["string", "number"],
+            "format": "ports"
+          },
+          "uniqueItems": true
+        },
+
+        "privileged": {"type": "boolean"},
+        "read_only": {"type": "boolean"},
+        "restart": {"type": "string"},
+        "runtime": {"type": "string"},
+        "scale": {"type": "number"},
+        "security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "shm_size": {"type": ["number", "string"]},
+        "sysctls": {"$ref": "#/definitions/list_or_dict"},
+        "pids_limit": {"type": ["number", "string"]},
+        "platform": {"type": "string"},
+        "stdin_open": {"type": "boolean"},
+        "stop_grace_period": {"type": "string", "format": "duration"},
+        "stop_signal": {"type": "string"},
+        "storage_opt": {"type": "object"},
+        "tmpfs": {"$ref": "#/definitions/string_or_list"},
+        "tty": {"type": "boolean"},
+        "ulimits": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-z]+$": {
+              "oneOf": [
+                {"type": "integer"},
+                {
+                  "type":"object",
+                  "properties": {
+                    "hard": {"type": "integer"},
+                    "soft": {"type": "integer"}
+                  },
+                  "required": ["soft", "hard"],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          }
+        },
+        "user": {"type": "string"},
+        "userns_mode": {"type": "string"},
+        "volumes": {"$ref": "#/definitions/volumes"},
+        "volume_driver": {"type": "string"},
+        "volumes_from": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "working_dir": {"type": "string"}
+      },
+
+      "dependencies": {
+        "memswap_limit": ["mem_limit"]
+      },
+      "patternProperties": {"^x-": {}},
+      "additionalProperties": false
+    },
+
+    "healthcheck": {
+      "id": "#/definitions/healthcheck",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "disable": {"type": "boolean"},
+        "interval": {"type": "string"},
+        "retries": {"type": "number"},
+        "start_period": {"type": "string"},
+        "test": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ]
+        },
+        "timeout": {"type": "string"}
+      }
+    },
+
+    "network": {
+      "id": "#/definitions/network",
+      "type": "object",
+      "properties": {
+        "driver": {"type": "string"},
+        "driver_opts": {
+          "type": "object",
+          "patternProperties": {
+            "^.+$": {"type": ["string", "number"]}
+          }
+        },
+        "ipam": {
+            "type": "object",
+            "properties": {
+                "driver": {"type": "string"},
+                "config": {
+                    "type": "array"
+                },
+                "options": {
+                  "type": "object",
+                  "patternProperties": {
+                    "^.+$": {"type": "string"}
+                  },
+                  "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "external": {
+          "type": ["boolean", "object"],
+          "properties": {
+            "name": {"type": "string"}
+          },
+          "additionalProperties": false
+        },
+        "internal": {"type": "boolean"},
+        "enable_ipv6": {"type": "boolean"},
+        "labels": {"$ref": "#/definitions/list_or_dict"}
+      },
+      "patternProperties": {"^x-": {}},
+      "additionalProperties": false
+    },
+
+    "volume": {
+      "id": "#/definitions/volume",
+      "type": ["object", "null"],
+      "properties": {
+        "driver": {"type": "string"},
+        "driver_opts": {
+          "type": "object",
+          "patternProperties": {
+            "^.+$": {"type": ["string", "number"]}
+          }
+        },
+        "external": {
+          "type": ["boolean", "object"],
+          "properties": {
+            "name": {"type": "string"}
+          },
+          "additionalProperties": false
+        },
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "name": {"type": "string"}
+      },
+      "patternProperties": {"^x-": {}},
+      "additionalProperties": false
+    },
+
+    "volumes": {
+      "id": "#/definitions/volumes",
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {"type": "string"},
+          {
+            "type": "object",
+            "required": ["type"],
+            "properties": {
+              "type": {"type": "string"},
+              "source": {"type": "string"},
+              "target": {"type": "string"},
+              "read_only": {"type": "boolean"},
+              "bind": {
+                "type": "object",
+                "properties": {
+                  "propagation": {"type": "string"}
+                },
+                "additionalProperties": false
+              },
+              "volume": {
+                "type": "object",
+                "properties": {
+                  "nocopy": {"type": "boolean"}
+                },
+                "additionalProperties": false
+              },
+              "tmpfs": {
+                "type": "object",
+                "properties": {
+                  "size": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "uniqueItems": true
+    },
+
+    "string_or_list": {
+      "oneOf": [
+        {"type": "string"},
+        {"$ref": "#/definitions/list_of_strings"}
+      ]
+    },
+
+    "list_of_strings": {
+      "type": "array",
+      "items": {"type": "string"},
+      "uniqueItems": true
+    },
+
+    "list_or_dict": {
+      "oneOf": [
+        {
+          "type": "object",
+          "patternProperties": {
+            ".+": {
+              "type": ["string", "number", "null"]
+            }
+          },
+          "additionalProperties": false
+        },
+        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
+      ]
+    },
+
+    "blkio_limit": {
+      "type": "object",
+      "properties": {
+        "path": {"type": "string"},
+        "rate": {"type": ["integer", "string"]}
+      },
+      "additionalProperties": false
+    },
+    "blkio_weight": {
+      "type": "object",
+      "properties": {
+        "path": {"type": "string"},
+        "weight": {"type": "integer"}
+      },
+      "additionalProperties": false
+    },
+
+    "constraints": {
+      "service": {
+        "id": "#/definitions/constraints/service",
+        "anyOf": [
+          {"required": ["build"]},
+          {"required": ["image"]}
+        ],
+        "properties": {
+          "build": {
+            "required": ["context"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -9,14 +9,18 @@ export enum SchemaVersion {
 	v1_0 = '',
 	v2_0 = '2',
 	v2_1 = '2.1',
+	v2_4 = '2.4',
 }
 
-export const DEFAULT_SCHEMA_VERSION = SchemaVersion.v2_1;
+export const DEFAULT_SCHEMA_VERSION = SchemaVersion.v2_4;
 
 const schemas: any = {};
 schemas[SchemaVersion.v1_0] = 'v1';
+// TODO: instead of keeping a schema for every version, we could just always
+// track the latest for each major version
 schemas[SchemaVersion.v2_0] = 'v2.0';
 schemas[SchemaVersion.v2_1] = 'v2.1';
+schemas[SchemaVersion.v2_4] = 'v2.4';
 
 function loadJSON(path: string): any {
 	const filePath = require.resolve(path);

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,14 +33,10 @@ export interface Service {
 		device_write_iops?: BlkioLimit[];
 	};
 
-	build?: {
-		context: string;
-		dockerfile?: string;
-		args?: Dict<string>;
-		labels?: Dict<string>;
-	};
+	build?: BuildConfig;
 
 	image?: string; // either image or build must be specified
+	init?: boolean;
 
 	cap_add?: ListOfUniqueItems<string>;
 	cap_drop?: ListOfUniqueItems<string>;
@@ -52,11 +48,14 @@ export interface Service {
 
 	cpu_shares?: number | string;
 	cpu_quota?: number | string;
+	cpu_rt_runtime?: number | string;
+	cpu_rt_period?: number | string;
 	cpuset?: string;
 
 	depends_on?: ListOfUniqueItems<string>;
 
 	devices?: ListOfUniqueItems<string>;
+	device_cgroup_rules?: ListOfUniqueItems<string>;
 
 	dns_opt?: ListOfUniqueItems<string>;
 	dns_search?: StringOrList;
@@ -79,6 +78,7 @@ export interface Service {
 		disable?: boolean;
 		retries?: number;
 		interval?: DurationValue;
+		start_period?: DurationValue;
 		timeout?: DurationValue;
 	};
 
@@ -132,9 +132,12 @@ export interface Service {
 
 	ports?: ListOfUniqueItems<string>;
 
+	platform?: string;
 	privileged?: boolean;
 	read_only?: boolean;
 	restart?: string;
+	runtime?: string;
+	scale?: number;
 	security_opt?: ListOfUniqueItems<string>;
 	stop_grace_period?: DurationValue;
 	stop_signal?: string;
@@ -199,11 +202,17 @@ export interface Composition {
 }
 
 export interface BuildConfig {
+	args?: Dict<string>;
+	cache_from?: ListOfUniqueItems<string>;
 	context: string;
 	dockerfile?: string;
-	args?: Dict<string>;
+	extra_hosts?: ListOfUniqueItems<string>;
+	isolation?: string;
 	labels?: Dict<string>;
+	network?: string;
+	shm_size?: number | string;
 	tag?: string;
+	target?: string;
 }
 
 export interface ImageDescriptor {

--- a/test/fixtures/default.json
+++ b/test/fixtures/default.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "2.4",
   "networks": {
     "n1": {},
     "n2": null
@@ -23,7 +23,11 @@
       "env_file": "./relative/parent1/parent2/parent3/../../twoupwards.env"
     },
     "s2": {
-      "build": "./s2",
+      "build": {
+        "context": "./s2",
+        "target": "stage1",
+        "network": "none"
+      },
       "depends_on": [
         "s1",
         "s3"
@@ -39,7 +43,10 @@
       ],
       "extra_hosts": {
         "foo": "127.0.0.1"
-      }
+      },
+      "volumes": [
+        "v2:/v2:ro"
+      ]
     },
     "s3": {
       "image": "some/image",
@@ -50,6 +57,20 @@
       ],
       "extra_hosts": [
         "bar:8.8.8.8"
+      ],
+      "tmpfs": [
+        "/tmp1"
+      ],
+      "volumes": [
+        {
+          "type": "volume",
+          "source": "v1",
+          "target": "/v1"
+        },
+        {
+          "type": "tmpfs",
+          "target": "/tmp2"
+        }
       ]
     }
   }

--- a/test/fixtures/test-v2.4.json
+++ b/test/fixtures/test-v2.4.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.4",
+  "services": {
+    "s1": { "build": "./" },
+    "s2": { "image": "some/image" }
+  }
+}


### PR DESCRIPTION
Bumps the supported compose version to the most recent v2 release.
The new properties include:
  * long volume syntax (new default internal representation of volume
    references)
  * more build config fields (including `target`)

Change-type: minor
Signed-off-by: Robert Günzler <robertg@balena.io>